### PR TITLE
Remove the Git unlink from CI

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -14,8 +14,6 @@ jobs:
   install:
     runs-on: ${{ inputs.runs-on }}
     steps:
-    - name: Unlink Git in virtual environment
-      run: brew unlink git@2.35.1
     - name: Checkout repository (for actions only)
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
I think the GitHub macos:latest or whatever must have moved on from the hardcoded Git version I was unlinking, so I'm trying to fix that here.